### PR TITLE
Fixes an ErrorException - Undefined offset: 0 in Collection.php:16

### DIFF
--- a/src/Franzose/ClosureTable/Collection.php
+++ b/src/Franzose/ClosureTable/Collection.php
@@ -13,7 +13,7 @@ class Collection extends \Illuminate\Database\Eloquent\Collection {
         {
            $current = $args[1];
         }
-        elseif ($items[0]->parent() !== null)
+        elseif (array_key_exists(0, $items) && $items[0]->parent() !== null)
         {
            $current = $items[0]->parent()->getKey();
         }


### PR DESCRIPTION
In my project, where evey user has a personal subset of categories, I
created a new user and he doesn't have any item in the categories table yet,
and i get an `ErrorException - Undefined offset: 0`. I have the same problem 
both calling tree() or filteredTree().
The problem is a lacking check for the existence of `$items[0]`, with an
empty set `$items` is not an array. Adding a check for the existence of
key 0 in `$items` array solves the problem, at least in my setup.

Here's the stack trace:

```
[2013-09-25 13:48:23] log.ERROR: exception 'ErrorException' with
message 'Undefined offset: 0' in
/Applications/MAMP/htdocs/prepper-laravel/vendor/franzose/closure-table/
src/Franzose/ClosureTable/Collection.php:16
Stack trace:
#0
/Applications/MAMP/htdocs/prepper-laravel/vendor/franzose/closure-table/
src/Franzose/ClosureTable/Collection.php(16):
Illuminate\Exception\Handler->handleError(8, 'Undefined offse...',
'/Applications/M...', 16, Array)
#1
/Applications/MAMP/htdocs/prepper-laravel/vendor/franzose/closure-table/
src/models/Entity.php(734): Franzose\ClosureTable\Collection->toTree()
#2
/Applications/MAMP/htdocs/prepper-laravel/app/controllers/CategoriesCont
roller.php(16): Franzose\ClosureTable\Entity::filteredTree('user_id',
'=', '2')
#3 [internal function]: CategoriesController->index()
#4
/Applications/MAMP/htdocs/prepper-laravel/vendor/laravel/framework/src/I
lluminate/Routing/Controllers/Controller.php(138):
call_user_func_array(Array, Array)
#5
/Applications/MAMP/htdocs/prepper-laravel/vendor/laravel/framework/src/I
lluminate/Routing/Controllers/Controller.php(115):
Illuminate\Routing\Controllers\Controller->callMethod('index', Array)
#6
/Applications/MAMP/htdocs/prepper-laravel/vendor/laravel/framework/src/I
lluminate/Routing/Router.php(985):
Illuminate\Routing\Controllers\Controller->callAction(Object(Illuminate\
Foundation\Application), Object(Illuminate\Routing\Router), 'index',
Array)
#7 [internal function]:
Illuminate\Routing\Router->Illuminate\Routing\{closure}()
#8
/Applications/MAMP/htdocs/prepper-laravel/vendor/laravel/framework/src/I
lluminate/Routing/Route.php(80): call_user_func_array(Object(Closure),
Array)
#9
/Applications/MAMP/htdocs/prepper-laravel/vendor/laravel/framework/src/I
lluminate/Routing/Route.php(47):
Illuminate\Routing\Route->callCallable()
#10
/Applications/MAMP/htdocs/prepper-laravel/vendor/laravel/framework/src/I
lluminate/Routing/Router.php(1016):
Illuminate\Routing\Route->run(Object(Illuminate\Http\Request))
#11
/Applications/MAMP/htdocs/prepper-laravel/vendor/laravel/framework/src/I
lluminate/Foundation/Application.php(530):
Illuminate\Routing\Router->dispatch(Object(Illuminate\Http\Request))
#12
/Applications/MAMP/htdocs/prepper-laravel/vendor/laravel/framework/src/I
lluminate/Foundation/Application.php(506):
Illuminate\Foundation\Application->dispatch(Object(Illuminate\Http\Reque
st))
#13 /Applications/MAMP/htdocs/prepper-laravel/public/index.php(49):
Illuminate\Foundation\Application->run()
#14 {main} [] []
```
