### PR TITLE
Fixes to Entity when specifying an initial position

### DIFF
--- a/src/Franzose/ClosureTable/Models/Entity.php
+++ b/src/Franzose/ClosureTable/Models/Entity.php
@@ -128,10 +128,11 @@ class Entity extends Eloquent implements EntityInterface {
      */
     public function setParentIdAttribute($value)
     {
-        $column = $this->getParentIdColumn();
-
+        if ($this->parent_id === $value) {
+            return;
+        }
         $this->old_parent_id = $this->parent_id;
-        $this->attributes[$column] = $value;
+        $this->attributes[$this->getParentIdColumn()] = $value;
     }
 
     /**
@@ -171,6 +172,9 @@ class Entity extends Eloquent implements EntityInterface {
      */
     public function setPositionAttribute($value)
     {
+        if ($this->position === $value) {
+            return;
+        }
         $this->old_position = $this->position;
         $this->attributes[$this->getPositionColumn()] = intval($value);
     }
@@ -212,6 +216,9 @@ class Entity extends Eloquent implements EntityInterface {
      */
     public function setRealDepthAttribute($value)
     {
+        if ($this->real_depth === $value) {
+            return;
+        }
         $this->old_real_depth = $this->real_depth;
         $this->attributes[$this->getRealDepthColumn()] = intval($value);
     }
@@ -270,6 +277,7 @@ class Entity extends Eloquent implements EntityInterface {
         static::created(function(Entity $entity)
         {
             static::echo_debug(PHP_EOL.'>>>>> BEGIN CREATED >>>>>'.PHP_EOL);
+            $entity->old_parent_id = false;
             $entity->old_position = $entity->position;
             $entity->insertNode();
             static::echo_debug(PHP_EOL.'<<<<< END CREATED <<<<<'.PHP_EOL);
@@ -1248,7 +1256,7 @@ class Entity extends Eloquent implements EntityInterface {
     {
         if ($this->isMoved === false)
         {
-            $this->position = $this->getNextAfterLastPosition();
+            $this->position = $this->position !== null ? $this->position : $this->getNextAfterLastPosition();
             $this->real_depth = $this->getNewRealDepth($this->parent_id);
         }
 
@@ -1362,7 +1370,7 @@ class Entity extends Eloquent implements EntityInterface {
             // TODO: There's probably a bug here where if you just created an entity and you set it to be
             // a root (parent_id = null) then it comes in here (while it should have gone in the else)
             // Reordering within the same ancestor
-            if ($this->old_parent_id == $this->parent_id)
+            if ($this->old_parent_id !== false && $this->old_parent_id == $this->parent_id)
             {
                 if ($this->position > $this->old_position)
                 {

--- a/tests/EntityTestCase.php
+++ b/tests/EntityTestCase.php
@@ -36,6 +36,7 @@ class EntityTestCase extends BaseTestCase {
         // TODO: Remove this when Laravel fixes the issue with model booting in tests
         if (self::$force_boot) {
             Entity::boot();
+            Page::boot();
         } else {
             self::$force_boot = true;
         }
@@ -92,6 +93,30 @@ class EntityTestCase extends BaseTestCase {
         $this->assertEquals($entity->position, $this->readAttribute($entity, 'old_position'));
         $this->assertEquals(null, $entity->parent_id);
         $this->assertEquals($entity->parent_id, $this->readAttribute($entity, 'old_parent_id'));
+    }
+
+    public function testCreateUseGivenPosition()
+    {
+        $this->assertEquals(1, Page::find(2)->position);
+
+        $entity = new Page(['title' => 'Item 1']);
+        $entity->position = 1;
+        $entity->save();
+
+        $this->assertEquals(1, $entity->position);
+        $this->assertEquals(2, Page::find(2)->position);
+    }
+
+    public function testCreateGivenPosition0()
+    {
+        $this->assertEquals(0, Page::find(1)->position);
+
+        $entity = new Page(['title' => 'Item 1']);
+        $entity->position = 0;
+        $entity->save();
+
+        $this->assertEquals(0, $entity->position);
+        $this->assertEquals(1, Page::find(1)->position);
     }
 
     public function testCreateDoesNotChangePositionOfSiblings()


### PR DESCRIPTION
Hello @franzose,

This PR fixes 2 issues related to the Entity when we give them an initial position before saving. Without this fix, the passed position is basically ignored and the position saved is the last for the parent given.

Furthermore, it includes the `$this->old_parent_id = false;` change that is required when creating a new entity otherwise it'll assume that the `old_parent_id` and the `parent_id` are the same (which is `NULL`). This way, setupReordering thinks the ancestor has changed, which uses the appropriate logic.

Hopefully all those fixes are getting us toward a stable and functional release :smile: 
