### PR TITLE
Update method signatures and artisan creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ sudo: false
 
 install: travis_retry composer install --no-interaction --prefer-source
 
+before_script:
+  - mysql -e 'create database closuretabletest;'
+
 script: vendor/bin/phpunit
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script: vendor/bin/phpunit
 branches:
   only:
     - master
+    - feature/laravel-5

--- a/src/Franzose/ClosureTable/Models/Entity.php
+++ b/src/Franzose/ClosureTable/Models/Entity.php
@@ -103,7 +103,7 @@ class Entity extends Eloquent implements EntityInterface {
         parent::__construct($attributes);
     }
 
-    public function newFromBuilder($attributes = array())
+    public function newFromBuilder($attributes = array(), $connection = null)
     {
         $instance = parent::newFromBuilder($attributes);
         $instance->old_parent_id = $instance->parent_id;
@@ -1249,7 +1249,7 @@ class Entity extends Eloquent implements EntityInterface {
      *
      * @param  EloquentBuilder  $query
      * @param  array            $options
-     * 
+     *
      * @return bool
      */
     protected function performInsert(EloquentBuilder $query, array $options = [])
@@ -1268,7 +1268,7 @@ class Entity extends Eloquent implements EntityInterface {
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  array                                  $options
-     * 
+     *
      * @return bool
      */
     protected function performUpdate(EloquentBuilder $query, array $options = [])

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -79,7 +79,7 @@ abstract class BaseTestCase extends TestCase {
             $options = [
                 'driver'    => 'mysql',
                 'host'      => 'localhost',
-                'database'  => 'closure-table-test',
+                'database'  => 'closuretabletest',
                 'username'  => 'root',
                 'password'  => '',
                 'prefix'    => '',

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -30,7 +30,7 @@ abstract class BaseTestCase extends TestCase {
             DB::statement('DROP TABLE IF EXISTS migrations');
         }
 
-        $artisan = $this->app->make('artisan');
+        $artisan = $this->app->make('Illuminate\Contracts\Console\Kernel');
         $artisan->call('migrate', [
             '--database' => 'closuretable',
             '--path' => '../tests/migrations'
@@ -103,4 +103,4 @@ abstract class BaseTestCase extends TestCase {
     {
         $this->assertEquals($actual, $expected, $message, $delta, $depth, true);
     }
-} 
+}


### PR DESCRIPTION
The method signature for `newFromBuilder` has changed with Laravel 5. The way artisan is called has changed as well. This fixes both issues.

It also fixed the travis-ci builds so that the database table is created before running the tests.