### PR TITLE
Suggested install version change in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install the package, put the following in your composer.json:
 
 ```json
 "require": {
-	"franzose/closure-table": "dev-master"
+	"franzose/closure-table": "3.1.*"
 }
 ```
 


### PR DESCRIPTION
Suggesting `dev-master` could break developers code if API changes occur.