### PR TITLE
'ctid' column is a system column with PostgreSQL so can't be used

### DIFF
--- a/src/Franzose/ClosureTable/Generators/stubs/migrations/closuretable-innodb.php
+++ b/src/Franzose/ClosureTable/Generators/stubs/migrations/closuretable-innodb.php
@@ -13,7 +13,7 @@ class {{closure_class}} extends Migration
 
             Schema::create('{{closure_table}}', function(Blueprint $table)
             {
-                $table->increments('ctid');
+                $table->increments('closure_id');
 
                 $table->integer('ancestor', false, true);
                 $table->integer('descendant', false, true);

--- a/src/Franzose/ClosureTable/Generators/stubs/migrations/closuretable.php
+++ b/src/Franzose/ClosureTable/Generators/stubs/migrations/closuretable.php
@@ -9,7 +9,7 @@ class {{closure_class}} extends Migration
     {
         Schema::create('{{closure_table}}', function(Blueprint $table)
         {
-            $table->increments('ctid');
+            $table->increments('closure_id');
 
             $table->integer('ancestor', false, true);
             $table->integer('descendant', false, true);

--- a/src/Franzose/ClosureTable/Models/ClosureTable.php
+++ b/src/Franzose/ClosureTable/Models/ClosureTable.php
@@ -28,7 +28,7 @@ class ClosureTable extends Eloquent implements ClosureTableInterface
      *
      * @var string
      */
-    protected $primaryKey = 'ctid';
+    protected $primaryKey = 'closure_id';
 
     /**
      * Indicates if the model should be timestamped.

--- a/tests/migrations/2014_01_18_163154_create_entities_closure_table.php
+++ b/tests/migrations/2014_01_18_163154_create_entities_closure_table.php
@@ -13,7 +13,7 @@ class CreateEntitiesClosureTable extends Migration
     public function up()
     {
         Schema::create('entities_closure', function (Blueprint $table) {
-            $table->increments('ctid');
+            $table->increments('closure_id');
             $table->unsignedInteger('ancestor');
             $table->unsignedInteger('descendant');
             $table->unsignedInteger('depth');


### PR DESCRIPTION
When trying to run the migrations on PostgreSQL an error is thrown because `ctid` is a system column (http://www.postgresql.org/docs/9.4/static/ddl-system-columns.html).

I've renamed the column to `closure_id` but if you have a preference for something else feel free to change it :smile: 