### PR TITLE
Dump the autoloader after creating the migrations

### DIFF
--- a/src/Franzose/ClosureTable/ClosureTableServiceProvider.php
+++ b/src/Franzose/ClosureTable/ClosureTableServiceProvider.php
@@ -1,6 +1,7 @@
 <?php
 namespace Franzose\ClosureTable;
 
+use Illuminate\Foundation\Composer;
 use Illuminate\Support\ServiceProvider;
 use Franzose\ClosureTable\Console\ClosureTableCommand;
 use Franzose\ClosureTable\Console\MakeCommand;
@@ -49,10 +50,7 @@ class ClosureTableServiceProvider extends ServiceProvider
         });
 
         $this->app['command.closuretable.make'] = $this->app->share(function ($app) {
-            $migrator = new Migrator($app['files']);
-            $modeler = new Modeler($app['files']);
-
-            return new MakeCommand($migrator, $modeler);
+            return $app['Franzose\ClosureTable\Console\MakeCommand'];
         });
 
         $this->commands('command.closuretable', 'command.closuretable.make');

--- a/src/Franzose/ClosureTable/Console/MakeCommand.php
+++ b/src/Franzose/ClosureTable/Console/MakeCommand.php
@@ -3,6 +3,7 @@ namespace Franzose\ClosureTable\Console;
 
 use Illuminate\Console\AppNamespaceDetectorTrait;
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Composer;
 use Symfony\Component\Console\Input\InputOption;
 use Franzose\ClosureTable\Generators\Migration;
 use Franzose\ClosureTable\Generators\Model;
@@ -51,19 +52,25 @@ class MakeCommand extends Command
      * @var array
      */
     protected $options;
+    /**
+     * @var Composer
+     */
+    private $composer;
 
     /**
      * Creates a new command instance.
      *
      * @param Migration $migrator
      * @param Model $modeler
+     * @param Composer $composer
      */
-    public function __construct(Migration $migrator, Model $modeler)
+    public function __construct(Migration $migrator, Model $modeler, Composer $composer)
     {
         parent::__construct();
 
         $this->migrator = $migrator;
         $this->modeler = $modeler;
+        $this->composer = $composer;
     }
 
     /**
@@ -91,6 +98,8 @@ class MakeCommand extends Command
             $path = pathinfo($file, PATHINFO_FILENAME);
             $this->line("      <fg=green;options=bold>create</fg=green;options=bold>  $path");
         }
+
+        $this->composer->dumpAutoloads();
     }
 
     /**


### PR DESCRIPTION
Composer needs to be injected into the MakeCommand c'tor.

Instead of manually creating each of the dependencies I've removed that and just let Laravel work things out with it's IoC.