### PR TITLE
remove hardcoded column names 'parent_id' and 'position'

### DIFF
--- a/src/Franzose/ClosureTable/Models/Entity.php
+++ b/src/Franzose/ClosureTable/Models/Entity.php
@@ -1106,7 +1106,7 @@ class Entity extends Eloquent implements EntityInterface
          */
         $instance = new static;
 
-        return $instance->orderBy('parent_id')->orderBy('position')
+        return $instance->orderBy($instance->getParentIdColumn())->orderBy($instance->getPositionColumn())
             ->get($instance->prepareTreeQueryColumns($columns))->toTree();
     }
 


### PR DESCRIPTION
change hardcoded column names 'parent_id' and 'position' to getParentIdColumn() and getPositionColumn() to prevent error on getTree() call with custom column names