### PR TITLE
Change fire to handle to make it compatible with laravel 5.5

### DIFF
--- a/src/Franzose/ClosureTable/Console/ClosureTableCommand.php
+++ b/src/Franzose/ClosureTable/Console/ClosureTableCommand.php
@@ -30,7 +30,7 @@ class ClosureTableCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->info('ClosureTable v' . CT::VERSION);
         $this->line('Closure Table database design pattern implementation for Laravel framework.');

--- a/src/Franzose/ClosureTable/Console/MakeCommand.php
+++ b/src/Franzose/ClosureTable/Console/MakeCommand.php
@@ -78,7 +78,7 @@ class MakeCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->prepareOptions();
         $this->writeMigrations();


### PR DESCRIPTION
As stated in the upgrade guide for laravel 5.5, the fire method should be renamed to handle.