### PR TITLE
Update Travis to test on Laravel 5.6 to 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,37 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+
+env:
+  - LARAVEL_VERSION=5.5.*
+  - LARAVEL_VERSION=5.6.*
+  - LARAVEL_VERSION=5.7.*
+  - LARAVEL_VERSION=5.8.*
+  - LARAVEL_VERSION=5.8.*
+  - LARAVEL_VERSION=6.*
+matrix:
+  exclude:
+    - php: 7.0
+      env: LARAVEL_VERSION=5.6.*
+    - php: 7.0
+      env: LARAVEL_VERSION=5.7.*
+    - php: 7.0
+      env: LARAVEL_VERSION=5.8.*
+    - php: 7.0
+      env: LARAVEL_VERSION=6.*
+    - php: 7.1
+      env: LARAVEL_VERSION=6.*
 
 sudo: false
+
+before_install:
+  # ensure that the specific Laravel version is required
+  - composer require "illuminate/support:${LARAVEL_VERSION}" --no-update
 
 install: travis_retry composer install --no-interaction --prefer-source
 
@@ -19,3 +44,6 @@ branches:
   only:
     - master
     - feature/laravel-5
+    # version tag, e.g. v1.0.0
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+    - /^\d+\.\d+?$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
   - 7.4
 
 env:
-  - LARAVEL_VERSION=5.5.*
   - LARAVEL_VERSION=5.6.*
   - LARAVEL_VERSION=5.7.*
   - LARAVEL_VERSION=5.8.*
@@ -19,11 +18,19 @@ env:
   - LARAVEL_VERSION=6.*
 matrix:
   exclude:
-    - php: 7.0
+    - php: 7.2
       env: LARAVEL_VERSION=5.6.*
-    - php: 7.0
+    - php: 7.3
+      env: LARAVEL_VERSION=5.6.*
+    - php: 7.3
       env: LARAVEL_VERSION=5.7.*
-    - php: 7.0
+    - php: 7.3
+      env: LARAVEL_VERSION=5.8.*
+    - php: 7.4
+      env: LARAVEL_VERSION=5.6.*
+    - php: 7.4
+      env: LARAVEL_VERSION=5.7.*
+    - php: 7.4
       env: LARAVEL_VERSION=5.8.*
     - php: 7.0
       env: LARAVEL_VERSION=6.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+services:
+  - mysql
+
 php:
   - 7.0
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,16 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=7.0",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "dev-master",
+        "phpunit/phpunit": "^6.5|^7.0|^8.0",
         "way/phpunit-wrappers": "dev-master",
         "way/laravel-test-helpers": "dev-master",
-        "mockery/mockery": "dev-master",
-        "orchestra/testbench": "dev-master",
-        "doctrine/dbal": "dev-master"
+        "mockery/mockery": "^1.1.0",
+        "orchestra/testbench": "^3.7|^3.8|^4.0|^5.0",
+        "doctrine/dbal": "^2.5"
     },
     "autoload": {
         "classmap": ["tests"],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="true"
-         syntaxCheck="true"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -19,7 +19,7 @@ abstract class BaseTestCase extends TestCase
     public static $debug = false;
     public static $sqlite_in_memory = false;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -32,15 +32,13 @@ abstract class BaseTestCase extends TestCase
             DB::statement('DROP TABLE IF EXISTS migrations');
         }
 
-        $artisan = $this->app->make('Illuminate\Contracts\Console\Kernel');
-        $artisan->call('migrate', [
-            '--database' => 'closuretable',
-            '--path' => '../tests/migrations'
-        ]);
+        // Load test migrations
+        $this->loadMigrationsFrom(__DIR__ . '/migrations');
 
-        $artisan->call('db:seed', [
+        // seed the database with default entities and values
+        $this->artisan('db:seed', [
             '--class' => 'Franzose\ClosureTable\Tests\Seeds\EntitiesSeeder'
-        ]);
+        ])->run();
 
         if (static::$debug) {
             Entity::$debug = true;
@@ -52,7 +50,7 @@ abstract class BaseTestCase extends TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         Mockery::close();
     }

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -97,6 +97,23 @@ abstract class BaseTestCase extends TestCase
      */
     protected function assertArrayValuesEquals(array $actual, array $expected, $message = '', $delta = 0.0, $depth = 10)
     {
-        $this->assertEquals($actual, $expected, $message, $delta, $depth, true);
+        $this->assertEqualsCanonicalizing($actual, $expected, $message, $delta, $depth);
+    }
+
+
+    /**
+     * Get the value of a private property on an object
+     * 
+     * @param mixed $object the object reference
+     * @param string $name the property name
+     * @return mixed the property value
+     */
+    protected function readPrivateProperty(&$object, $name)
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $property = $reflection->getProperty($name);
+        $property->setAccessible(true);
+
+        return $property->getValue($object);
     }
 }

--- a/tests/ClosureTableTestCase.php
+++ b/tests/ClosureTableTestCase.php
@@ -2,6 +2,7 @@
 namespace Franzose\ClosureTable\Tests;
 
 use Franzose\ClosureTable\Models\ClosureTable;
+use Illuminate\Database\QueryException;
 
 class ClosureTableTestCase extends BaseTestCase
 {
@@ -25,7 +26,7 @@ class ClosureTableTestCase extends BaseTestCase
      */
     protected $depthColumn;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -36,11 +37,12 @@ class ClosureTableTestCase extends BaseTestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @dataProvider insertNodeProvider
      */
     public function testInsertNodeValidatesItsArguments($ancestorId, $descendantId)
     {
+        $this->expectException(QueryException::class);
+
         $this->ctable->insertNode($ancestorId, $descendantId);
     }
 
@@ -53,11 +55,10 @@ class ClosureTableTestCase extends BaseTestCase
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testMoveNodeToValidatesItsArgument()
     {
+        $this->expectException(QueryException::class);
+
         $this->ctable->moveNodeTo('wrong');
     }
 

--- a/tests/EntityTestCase.php
+++ b/tests/EntityTestCase.php
@@ -6,6 +6,7 @@ use Franzose\ClosureTable\Models\ClosureTable;
 use Mockery;
 use Franzose\ClosureTable\Models\Entity;
 use Franzose\ClosureTable\Tests\Models\Page;
+use InvalidArgumentException;
 
 class EntityTestCase extends BaseTestCase
 {
@@ -187,11 +188,10 @@ class EntityTestCase extends BaseTestCase
         $this->assertEquals($entity1->parent_id, $this->readAttribute($entity1, 'old_parent_id'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testMoveToThrowsException()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->entity->moveTo(0, $this->entity);
     }
 

--- a/tests/EntityTestCase.php
+++ b/tests/EntityTestCase.php
@@ -32,7 +32,7 @@ class EntityTestCase extends BaseTestCase
      */
     protected $childrenRelationIndex;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/EntityTestCase.php
+++ b/tests/EntityTestCase.php
@@ -104,16 +104,16 @@ class EntityTestCase extends BaseTestCase
         $entity = new Page(['title' => 'Item 1']);
 
         $this->assertEquals(null, $entity->position);
-        $this->assertEquals(null, $this->readAttribute($entity, 'old_position'));
+        $this->assertEquals(null, $this->readPrivateProperty($entity, 'old_position'));
         $this->assertEquals(null, $entity->parent_id);
-        $this->assertEquals(null, $this->readAttribute($entity, 'old_parent_id'));
+        $this->assertEquals(null, $this->readPrivateProperty($entity, 'old_parent_id'));
 
         $entity->save();
 
         $this->assertEquals(9, $entity->position);
-        $this->assertEquals($entity->position, $this->readAttribute($entity, 'old_position'));
+        $this->assertEquals($entity->position, $this->readPrivateProperty($entity, 'old_position'));
         $this->assertEquals(null, $entity->parent_id);
-        $this->assertEquals($entity->parent_id, $this->readAttribute($entity, 'old_parent_id'));
+        $this->assertEquals($entity->parent_id, $this->readPrivateProperty($entity, 'old_parent_id'));
     }
 
     /**
@@ -177,15 +177,15 @@ class EntityTestCase extends BaseTestCase
 
         $this->assertEquals(8, Page::find(9)->position); // Sibling node that shouldn't move
 
-        $this->assertEquals($entity1->position, $this->readAttribute($entity1, 'old_position'), 'Position should be the same after a load');
-        $this->assertEquals($entity1->parent_id, $this->readAttribute($entity1, 'old_parent_id'), 'Parent should be the same after a load');
+        $this->assertEquals($entity1->position, $this->readPrivateProperty($entity1, 'old_position'), 'Position should be the same after a load');
+        $this->assertEquals($entity1->parent_id, $this->readPrivateProperty($entity1, 'old_parent_id'), 'Parent should be the same after a load');
 
         $entity1->title = 'New title';
         $entity1->save();
 
         $this->assertEquals(8, Page::find(9)->position, 'Sibling node should not have moved');
-        $this->assertEquals($entity1->position, $this->readAttribute($entity1, 'old_position'));
-        $this->assertEquals($entity1->parent_id, $this->readAttribute($entity1, 'old_parent_id'));
+        $this->assertEquals($entity1->position, $this->readPrivateProperty($entity1, 'old_position'));
+        $this->assertEquals($entity1->parent_id, $this->readPrivateProperty($entity1, 'old_parent_id'));
     }
 
     public function testMoveToThrowsException()

--- a/tests/migrations/2014_01_18_162506_create_entities_table.php
+++ b/tests/migrations/2014_01_18_162506_create_entities_table.php
@@ -16,8 +16,8 @@ class CreateEntitiesTable extends Migration
             $table->increments('id');
             $table->unsignedInteger('parent_id')->nullable();
             $table->string('title')->default('The Title');
-            $table->text('excerpt');
-            $table->longText('body');
+            $table->text('excerpt')->nullable();
+            $table->longText('body')->nullable();
             $table->integer('position', false, true);
             $table->integer('real_depth', false, true);
             $table->softDeletes();


### PR DESCRIPTION
Looking at #222 I was questioning myself if everything is compatible with latest PHP and Laravel versions.

The main goal of this pull request is to ensure that automated tests on Travis CI can be executed for all the supported Laravel and PHP versions, so I did the following changes:

- Make PHP 7.0 the minimum PHP version
- Update composer.json to ensure a Laravel package is specified to mark the version under testing
- Update composer.json to ensure that the dev dependencies can be resolved to an installable set of packages for the supported PHP and Laravel version
- Update unit tests to remove deprecation notices 