### PR TITLE
Improve compatibility support for PHPUnit 7 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ branches:
   only:
     - master
     - 6.x
-    - travis-ci-for-6.x
+    - improve-travis
     # version tag, e.g. v1.0.0
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
     - /^\d+\.\d+?$/

--- a/tests/script-change-testcase-return-type.php
+++ b/tests/script-change-testcase-return-type.php
@@ -9,12 +9,19 @@ if (PHP_VERSION_ID < 70100) {
     exit(0);
 }
 
-$filesToPatch = [
-    'tests/BaseTestCase.php',
-    'tests/Console/MakeCommandTests.php'
-];
+require_once './vendor/autoload.php';
 
-foreach ($filesToPatch as $path) {
+use Symfony\Component\Finder\Finder;
+
+$finder = new Finder();
+$finder->files()
+    ->ignoreVCS(false)
+    ->in(__DIR__)
+    ->name('*.php')
+    ->notName('script-change-testcase-return-type.php')->contains('use Orchestra\Testbench\TestCase;');
+
+foreach ($finder as $file) {
+    $absoluteFilePath = $file->getRealPath();
     $contents = file_get_contents($path);
     $contents = str_replace(
         ['public function setUp()', 'public function tearDown()'],

--- a/tests/script-change-testcase-return-type.php
+++ b/tests/script-change-testcase-return-type.php
@@ -18,10 +18,11 @@ $finder->files()
     ->ignoreVCS(false)
     ->in(__DIR__)
     ->name('*.php')
-    ->notName('script-change-testcase-return-type.php')->contains('use Orchestra\Testbench\TestCase;');
+    ->notName('script-change-testcase-return-type.php')
+    ->contains('use Orchestra\Testbench\TestCase;');
 
 foreach ($finder as $file) {
-    $absoluteFilePath = $file->getRealPath();
+    $path = $file->getRealPath();
     $contents = file_get_contents($path);
     $contents = str_replace(
         ['public function setUp()', 'public function tearDown()'],


### PR DESCRIPTION
As a different number of major versions of PHPUnit are required to cover all the compatibility matrix, I had to manually change a file before running `phpunit` to apply the breaking changes introduced in [PHPUnit 8](https://phpunit.de/announcements/phpunit-8.html).

The original approach was to change the `BaseTestCase` content before running the tests. This had a drawback because not all tests might start from it.

The current pull request revise the approach to search all files under `tests` for  `Orchestra\Testbench\TestCase` and then insert the return `void` for `setUp` and `tearDown` methods.