### PR TITLE
Test on Postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: php
 
 services:
   - mysql
+  - postgresql
+
+cache:
+  directories:
+  - .composer
 
 php:
   - 5.6
@@ -13,35 +18,62 @@ php:
 
 env:
   - LARAVEL_VERSION=5.4.*
+  - LARAVEL_VERSION=5.4.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
   - LARAVEL_VERSION=5.5.*
+  - LARAVEL_VERSION=5.5.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
   - LARAVEL_VERSION=5.6.*
+  - LARAVEL_VERSION=5.6.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
   - LARAVEL_VERSION=5.7.*
+  - LARAVEL_VERSION=5.7.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
   - LARAVEL_VERSION=5.8.*
+  - LARAVEL_VERSION=5.8.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
   - LARAVEL_VERSION=6.*
+  - LARAVEL_VERSION=6.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
   - LARAVEL_VERSION=7.*
+  - LARAVEL_VERSION=7.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
 
 matrix:
   exclude:
     - php: 5.6
       env: LARAVEL_VERSION=5.5.*
     - php: 5.6
+      env: LARAVEL_VERSION=5.5.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 5.6
       env: LARAVEL_VERSION=5.6.*
     - php: 7.0
       env: LARAVEL_VERSION=5.6.*
     - php: 7.4
       env: LARAVEL_VERSION=5.6.*
     - php: 5.6
+      env: LARAVEL_VERSION=5.6.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.0
+      env: LARAVEL_VERSION=5.6.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.4
+      env: LARAVEL_VERSION=5.6.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 5.6
       env: LARAVEL_VERSION=5.7.*
     - php: 7.0
       env: LARAVEL_VERSION=5.7.*
     - php: 7.4
       env: LARAVEL_VERSION=5.7.*
     - php: 5.6
+      env: LARAVEL_VERSION=5.7.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.0
+      env: LARAVEL_VERSION=5.7.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.4
+      env: LARAVEL_VERSION=5.7.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 5.6
       env: LARAVEL_VERSION=5.8.*
     - php: 7.0
       env: LARAVEL_VERSION=5.8.*
     - php: 7.1
       env: LARAVEL_VERSION=5.8.*
+    - php: 5.6
+      env: LARAVEL_VERSION=5.8.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.0
+      env: LARAVEL_VERSION=5.8.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.1
+      env: LARAVEL_VERSION=5.8.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
     - php: 5.6
       env: LARAVEL_VERSION=6.*
     - php: 7.0
@@ -49,11 +81,23 @@ matrix:
     - php: 7.1
       env: LARAVEL_VERSION=6.*
     - php: 5.6
+      env: LARAVEL_VERSION=6.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.0
+      env: LARAVEL_VERSION=6.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.1
+      env: LARAVEL_VERSION=6.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 5.6
       env: LARAVEL_VERSION=7.*
     - php: 7.0
       env: LARAVEL_VERSION=7.*
     - php: 7.1
       env: LARAVEL_VERSION=7.*
+    - php: 5.6
+      env: LARAVEL_VERSION=7.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.0
+      env: LARAVEL_VERSION=7.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.1
+      env: LARAVEL_VERSION=7.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
     - php: 7.1
       env: LARAVEL_VERSION=5.4.*
     - php: 7.2
@@ -62,14 +106,18 @@ matrix:
       env: LARAVEL_VERSION=5.4.*
     - php: 7.4
       env: LARAVEL_VERSION=5.4.*
-
-jobs:
-  fast_finish: true
-
-sudo: false
+    - php: 7.1
+      env: LARAVEL_VERSION=5.4.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.2
+      env: LARAVEL_VERSION=5.4.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.3
+      env: LARAVEL_VERSION=5.4.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
+    - php: 7.4
+      env: LARAVEL_VERSION=5.4.* DB_DRIVER=pgsql DB_PORT=5432 DB_USERNAME=travis DB_NAME=travis
 
 # ensure that the specific Laravel version is required
 before_install:
+  - export COMPOSER_CACHE_DIR=`pwd`/.composer
   - composer require "laravel/framework:${LARAVEL_VERSION}" --no-update
 
 install: composer update --no-interaction --prefer-dist
@@ -86,6 +134,7 @@ branches:
     - master
     - 6.x
     - improve-travis
+    - postgres-testing
     # version tag, e.g. v1.0.0
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
     - /^\d+\.\d+?$/


### PR DESCRIPTION
This Pull Request is about running tests on Postgres in addition to MySQL.

The Travis CI exclusion matrix is getting bigger because all environment variables needs to be added to exclude a particular combination. 

All supported Laravel versions are tested with MySQL and Postgres.