### PR TITLE
Unbind relations only when the entity is not recently created

### DIFF
--- a/src/Models/ClosureTable.php
+++ b/src/Models/ClosureTable.php
@@ -85,7 +85,7 @@ class ClosureTable extends Eloquent implements ClosureTableInterface
      * @param mixed $ancestorId
      * @return void
      */
-    public function moveNodeTo($ancestorId = null)
+    public function moveNodeTo($ancestorId = null, $wasRecentlyCreated = false)
     {
         $table = $this->getPrefixedTable();
         $ancestor = $this->getAncestorColumn();
@@ -97,7 +97,9 @@ class ClosureTable extends Eloquent implements ClosureTableInterface
             return;
         }
 
-        $this->unbindRelationships();
+        if (! $wasRecentlyCreated) {
+            $this->unbindRelationships();
+        }
 
         // Since we have already unbound the node relationships,
         // given null ancestor id, we have nothing else to do,

--- a/src/Models/Entity.php
+++ b/src/Models/Entity.php
@@ -318,7 +318,7 @@ class Entity extends Eloquent implements EntityInterface
             }
 
             if ($parentIdChanged) {
-                $entity->closure->moveNodeTo($entity->parent_id);
+                $entity->closure->moveNodeTo($entity->parent_id, $entity->wasRecentlyCreated);
             }
         });
     }


### PR DESCRIPTION
If I'm not missing anything, `unbindRelationships` doesn't need to be called for recently created entities. It issues DELETE query which causes performance issue from time to time, and even worse, deadlocks on some RDBs (e.g. mysql) because of gap lock. This PR stops calling that function by referring entity's `wasRecentlyCreated` property.