### PR TITLE
feat: add parent_id column to fillable at construct

### DIFF
--- a/src/Models/Entity.php
+++ b/src/Models/Entity.php
@@ -115,9 +115,10 @@ class Entity extends Eloquent implements EntityInterface
      */
     public function __construct(array $attributes = [])
     {
-        $position = $this->getPositionColumn();
+        $position   = $this->getPositionColumn();
+        $parent_id  = $this->getParentIdColumn();
 
-        $this->fillable(array_merge($this->getFillable(), [$position]));
+        $this->fillable(array_merge($this->getFillable(), [$position, $parent_id]));
 
         if (isset($attributes[$position]) && $attributes[$position] < 0) {
             $attributes[$position] = 0;


### PR DESCRIPTION
#### Issue : #246 
What's change?  : Add `parent_id` to fillable while construct at `src/Models/Entity.php` → `parent_id` null when save node