### PR TITLE
fix: address issue with createFromArray described in #242

### DIFF
--- a/examples/tree.php
+++ b/examples/tree.php
@@ -3,33 +3,22 @@ declare(strict_types=1);
 
 namespace App;
 
+// Explicit positions are preserved on initial insert, even if input order is different.
 Node::createFromArray([
-    'id' => 1,
-    'children' => [
-        [
-            'id' => 2,
-            'children' => [
-                [
-                    'id' => 3,
-                    'children' => [
-                        [
-                            'id' => 4,
-                            'children' => [
-                                [
-                                    'id' => 5,
-                                    'children' => [
-                                        [
-                                            'id' => 6,
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ]
-    ]
+    [
+        'id' => 1,
+        'children' => [
+            ['id' => 2, 'position' => 2],
+            ['id' => 3, 'position' => 0],
+            ['id' => 4, 'position' => 1],
+            [
+                'id' => 5,
+                'children' => [
+                    ['id' => 6],
+                ],
+            ],
+        ],
+    ],
 ]);
 
 Node::find(4)->deleteSubtree();

--- a/tests/Entity/TreeTests.php
+++ b/tests/Entity/TreeTests.php
@@ -207,4 +207,45 @@ class TreeTests extends BaseTestCase
         static::assertEquals(700, $childrenOf600->get(0)->id);
         static::assertEquals(800, $childrenOf600->get(1)->id);
     }
+
+    public function testCreateFromArrayPreservesExplicitPositions(): void
+    {
+        $parent = Page::create(['title' => 'Root']);
+
+        Page::createFromArray([
+            ['id' => 301, 'title' => 'C', 'position' => 2],
+            ['id' => 302, 'title' => 'A', 'position' => 0],
+            ['id' => 303, 'title' => 'B', 'position' => 1],
+        ], $parent);
+
+        static::assertEquals(2, Page::find(301)->position);
+        static::assertEquals(0, Page::find(302)->position);
+        static::assertEquals(1, Page::find(303)->position);
+    }
+
+    public function testCreateFromArrayPreservesExplicitPositionGaps(): void
+    {
+        $parent = Page::create(['title' => 'Root gaps']);
+
+        Page::createFromArray([
+            ['id' => 304, 'title' => 'Gapped', 'position' => 5],
+        ], $parent);
+
+        static::assertEquals(5, Page::find(304)->position);
+    }
+
+    public function testCreateFromArrayAssignsPositionsWhenMissing(): void
+    {
+        $parent = Page::create(['title' => 'Root implicit']);
+
+        Page::createFromArray([
+            ['id' => 305, 'title' => 'First'],
+            ['id' => 306, 'title' => 'Second'],
+            ['id' => 307, 'title' => 'Third'],
+        ], $parent);
+
+        static::assertEquals(0, Page::find(305)->position);
+        static::assertEquals(1, Page::find(306)->position);
+        static::assertEquals(2, Page::find(307)->position);
+    }
 }


### PR DESCRIPTION
## Issue
https://github.com/franzose/ClosureTable/issues/242

# Summary
1. Preserve explicit position values on initial insert while keeping existing move/update clamping behavior.
2. Ensure `createFromArray()` inserts are ordered by explicit positions (stable) to avoid sibling reordering shifts.
3. Add regression tests for explicit positions, position gaps, and implicit positioning.
4. Update [examples](https://github.com/franzose/ClosureTable/blob/7.x/examples/tree.php) to document the fixed behavior.