### PR TITLE
Fix positioning bug when creating new nodes

### DIFF
--- a/src/Models/Entity.php
+++ b/src/Models/Entity.php
@@ -278,7 +278,7 @@ class Entity extends Eloquent implements EntityInterface
             if ($entity->isDirty($entity->getPositionColumn())) {
                 $latest = static::getLatestPosition($entity);
 
-                if (!$entity->isReparenting) {
+                if (!$entity->isReparenting && $entity->exists) {
                     $latest--;
                 }
 


### PR DESCRIPTION
When creating a new node with both a `parent_id` and `position` specified, the positioning is set incorrectly. The `$latest--` subtraction, which ensures that the position value does not balloon should not run when creating a new node as now you do want to allow the position number to increase. 

### Example:
I'm creating N3 with the `parent_id` of N1 and a `position` of `1`. The figure below is how it should turn out. In the saving step, `Entity::getLatestPosition()` correctly returns 1 (as the position of N2 is 0). However this is subtracted to 0 as the position column is "dirty" and we're "reparenting".
```
   N1
   |
|------|
N2    (N3)
```